### PR TITLE
解决找不到jieba.hpp问题

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,8 +35,8 @@ else(WIN32)
 	ENDIF (WITH_STEMMER)
 endif (WIN32)
 
-include_directories("${SPHINXSEARCH_SOURCE_DIR}/cppjieba/include")
-include_directories("${SPHINXSEARCH_SOURCE_DIR}/cppjieba/deps")
+target_include_directories("${SPHINXSEARCH_SOURCE_DIR}/cppjieba/include")
+target_include_directories("${SPHINXSEARCH_SOURCE_DIR}/cppjieba/deps")
 
 #if(CMAKE_CONFIGURATION_TYPES)
 if (NOT WIN32)


### PR DESCRIPTION
新版本cmake推荐用target_include_directories替代include_directories